### PR TITLE
Change blog title. Removed 'header' reference because it's no longer...

### DIFF
--- a/blogpost.html
+++ b/blogpost.html
@@ -11,7 +11,7 @@
     <div id="Container">
         <div id="Header">
             <img id="logo" src="./img/gnu-vector.png" alt="GNU logo">
-            <span id="tagline">This is not a blog, this is "The blog"</span>
+            <span id="tagline">This is not a blog, this is "THE BLOG"</span>
         </div>
         <div id="Post">
             <h1>The change</h1>

--- a/blogpost.html
+++ b/blogpost.html
@@ -11,7 +11,7 @@
     <div id="Container">
         <div id="Header">
             <img id="logo" src="./img/gnu-vector.png" alt="GNU logo">
-            <span id="tagline">This is not a blog, it's "The blog" from header.</span>
+            <span id="tagline">This is not a blog, this is "The blog"</span>
         </div>
         <div id="Post">
             <h1>The change</h1>


### PR DESCRIPTION
The blog title had a reference to the header branch, but we no longer require it because all has been merged to 'main'.